### PR TITLE
Add support for custom connection name

### DIFF
--- a/src/Traits/SoftDeletes.js
+++ b/src/Traits/SoftDeletes.js
@@ -36,7 +36,7 @@ class SoftDeletes {
       await this.constructor.$hooks.before.exec('delete', this)
 
       const now = new Date()
-      const query = Database.table(this.constructor.table)
+      const query = Database.connection(Model.connection).table(this.constructor.table)
         .where(this.constructor.primaryKey, this.primaryKeyValue)
 
       const updatePromise = force
@@ -59,7 +59,7 @@ class SoftDeletes {
     Model.prototype.restore = async function () {
       await this.constructor.$hooks.before.exec('restore', this)
 
-      const query = Database.table(this.constructor.table)
+      const query = Database.connection(Model.connection).table(this.constructor.table)
       const affected = await query.where(this.constructor.primaryKey, this.primaryKeyValue)
         .update({ [deletedAtColumn]: null })
 

--- a/src/Traits/SoftDeletes.js
+++ b/src/Traits/SoftDeletes.js
@@ -59,7 +59,8 @@ class SoftDeletes {
     Model.prototype.restore = async function () {
       await this.constructor.$hooks.before.exec('restore', this)
 
-      const query = Database.connection(Model.connection).table(this.constructor.table)
+      const query = Database.connection(Model.connection)
+        .table(this.constructor.table)
       const affected = await query.where(this.constructor.primaryKey, this.primaryKeyValue)
         .update({ [deletedAtColumn]: null })
 

--- a/src/Traits/SoftDeletes.js
+++ b/src/Traits/SoftDeletes.js
@@ -36,7 +36,8 @@ class SoftDeletes {
       await this.constructor.$hooks.before.exec('delete', this)
 
       const now = new Date()
-      const query = Database.connection(Model.connection).table(this.constructor.table)
+      const query = Database.connection(Model.connection)
+        .table(this.constructor.table)
         .where(this.constructor.primaryKey, this.primaryKeyValue)
 
       const updatePromise = force


### PR DESCRIPTION
Currently use the default connection for delete() and restore(), if the system have 2 or more different connection(database) that use the connection getter will have a 'database.table' doesn't exist error